### PR TITLE
feat(kafka): Implement admin client with builder

### DIFF
--- a/src/admin/builder.rs
+++ b/src/admin/builder.rs
@@ -1,0 +1,25 @@
+use super::types::AdminClient;
+use crate::error::Error;
+use rdkafka::ClientConfig;
+
+/// Builder for creating an AdminClient with custom configuration
+pub struct AdminClientBuilder {
+    config: ClientConfig,
+}
+
+impl AdminClientBuilder {
+    pub fn new() -> Self {
+        let config = ClientConfig::new();
+        Self { config }
+    }
+
+    pub fn bootstrap_servers(mut self, servers: &[&str]) -> Self {
+        self.config.set("bootstrap.servers", servers.join(","));
+        self
+    }
+
+    pub async fn build(self) -> Result<AdminClient, Error> {
+        let admin_client = self.config.create()?;
+        Ok(AdminClient::new(admin_client).await?)
+    }
+}

--- a/src/admin/builder.rs
+++ b/src/admin/builder.rs
@@ -14,6 +14,7 @@ impl AdminClientBuilder {
     }
 
     pub fn bootstrap_servers(mut self, servers: &[&str]) -> Self {
+        assert!(!servers.is_empty(), "Bootstrap servers list cannot be empty");
         self.config.set("bootstrap.servers", servers.join(","));
         self
     }

--- a/src/admin/builder.rs
+++ b/src/admin/builder.rs
@@ -1,4 +1,4 @@
-use super::types::AdminClient;
+use super::types::{AdminClient, DefaultAdminClient};
 use crate::error::Error;
 use rdkafka::ClientConfig;
 
@@ -14,13 +14,28 @@ impl AdminClientBuilder {
     }
 
     pub fn bootstrap_servers(mut self, servers: &[&str]) -> Self {
-        assert!(!servers.is_empty(), "Bootstrap servers list cannot be empty");
         self.config.set("bootstrap.servers", servers.join(","));
         self
     }
 
+    pub fn client_id(mut self, client_id: &str) -> Self {
+        self.config.set("client.id", client_id);
+        self
+    }
+
+    pub fn set(mut self, key: &str, value: &str) -> Self {
+        self.config.set(key, value);
+        self
+    }
+
     pub async fn build(self) -> Result<AdminClient, Error> {
-        let admin_client = self.config.create()?;
-        Ok(AdminClient::new(admin_client).await?)
+        let admin_client: DefaultAdminClient = self.config.create()?;
+        AdminClient::new(admin_client).await
+    }
+}
+
+impl Default for AdminClientBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/admin/client.rs
+++ b/src/admin/client.rs
@@ -25,6 +25,7 @@ impl AdminClient {
         })
     }
 
+    #[instrument(skip(self))]
     pub async fn create_topic(
         &self,
         name: &str,
@@ -66,6 +67,7 @@ impl AdminClient {
         }
     }
 
+    #[instrument(skip(self))]
     pub async fn delete_topic(&self, name: &str) -> AdminResult<()> {
         let opts = AdminOptions::new();
 

--- a/src/admin/client.rs
+++ b/src/admin/client.rs
@@ -65,4 +65,22 @@ impl AdminClient {
             Err(e) => Err(e.into()),
         }
     }
+
+    pub async fn delete_topic(&self, name: &str) -> AdminResult<()> {
+        let opts = AdminOptions::new();
+
+        match self.admin_client.delete_topics(&[name], &opts).await {
+            Ok(results_vec) => match &results_vec[0] {
+                Ok(deleted_name) => {
+                    event!(Level::INFO, "Deleted topic {}", deleted_name);
+                    Ok(())
+                }
+                Err(e) => {
+                    event!(Level::ERROR, "Failed to delete topic {}, {:?}", e.0, e.1);
+                    Err(KafkaError::AdminOp(e.1).into())
+                }
+            },
+            Err(e) => Err(e.into()),
+        }
+    }
 }

--- a/src/admin/client.rs
+++ b/src/admin/client.rs
@@ -1,0 +1,33 @@
+use rdkafka::admin::{AdminOptions, NewTopic};
+use std::sync::Arc;
+
+use super::types::{AdminClient, AdminResult, DefaultAdminClient};
+
+impl AdminClient {
+    pub async fn new(admin_client: DefaultAdminClient) -> AdminResult<Self> {
+        Ok(Self {
+            admin_client: Arc::new(admin_client),
+        })
+    }
+
+    pub async fn create_topic(
+        &self,
+        name: &str,
+        num_partitions: u16,
+        replication_factor: u16,
+    ) -> AdminResult<()> {
+        let opts = AdminOptions::new();
+        let topic = NewTopic {
+            name,
+            num_partitions: num_partitions.into(),
+            replication: rdkafka::admin::TopicReplication::Fixed(replication_factor.into()),
+            config: vec![
+                ("compression.type", "zstd"),
+                ("auto.offset.reset", "beginning"),
+            ],
+        };
+
+        self.admin_client.create_topics([&topic], &opts).await?;
+        Ok(())
+    }
+}

--- a/src/admin/client.rs
+++ b/src/admin/client.rs
@@ -1,10 +1,24 @@
-use rdkafka::admin::{AdminOptions, NewTopic};
-use std::sync::Arc;
-
 use super::types::{AdminClient, AdminResult, DefaultAdminClient};
+use rdkafka::admin::{AdminOptions, NewTopic, ResourceSpecifier};
+use std::sync::Arc;
+use tracing::{event, instrument, Level};
 
 impl AdminClient {
+    #[instrument(skip(admin_client))]
     pub async fn new(admin_client: DefaultAdminClient) -> AdminResult<Self> {
+        let opts = AdminOptions::new();
+        let configs = ResourceSpecifier::Topic("_schemas");
+
+        if let Err(e) = admin_client.describe_configs([&configs], &opts).await {
+            event!(
+                Level::ERROR,
+                "Failed to connect admin client to cluster: {}",
+                e
+            );
+            return Err(e.into());
+        }
+
+        event!(Level::INFO, "Connected admin client to Kafka cluster");
         Ok(Self {
             admin_client: Arc::new(admin_client),
         })

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,0 +1,12 @@
+mod builder;
+mod client;
+mod types;
+
+pub use builder::AdminClientBuilder;
+pub use types::AdminClient;
+
+impl AdminClient {
+    pub fn builder() -> AdminClientBuilder {
+        AdminClientBuilder::new()
+    }
+}

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -11,3 +11,11 @@ pub type AdminResult<T> = Result<T, Error>;
 pub struct AdminClient {
     pub(crate) admin_client: Arc<DefaultAdminClient>,
 }
+
+impl std::fmt::Debug for AdminClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AdminClient")
+            .field("admin_client", &"<admin_client>")
+            .finish()
+    }
+}

--- a/src/admin/types.rs
+++ b/src/admin/types.rs
@@ -1,0 +1,13 @@
+use rdkafka::client::DefaultClientContext;
+use rdkafka::admin::AdminClient as RDKafkaAdminClient;
+use std::sync::Arc;
+use crate::error::Error;
+
+pub type DefaultAdminClient = RDKafkaAdminClient<DefaultClientContext>;
+pub type AdminResult<T> = Result<T, Error>;
+
+/// Admin client for managing Kafka topics and configurations
+#[derive(Clone)]
+pub struct AdminClient {
+    pub(crate) admin_client: Arc<DefaultAdminClient>,
+}


### PR DESCRIPTION
## Overview

This pull request introduces a new `AdminClient` for managing Kafka topics and configurations. It includes the implementation of a builder pattern for creating an `AdminClient` with custom configurations, and several methods for topic management. The most important changes include the creation of the `AdminClientBuilder`, new methods for creating and deleting topics, and updated module structure.

## Changes

* [`src/admin/builder.rs`](diffhunk://#diff-366ed3439a75b3bb05e2005e883a0876f394a495145d8833df39c004d0297055R1-R41): Added a new `AdminClientBuilder` struct for creating an `AdminClient` with custom configurations. This includes methods for setting bootstrap servers, client ID, and other configurations, as well as an asynchronous `build` method to create the `AdminClient`.
* [`src/admin/client.rs`](diffhunk://#diff-8ff72a70587007217999123a48a6182c95c18a3a0c9f84dfc44117c87ed2e6f2R1-R88): Implemented the `AdminClient` struct with methods for connecting to a Kafka cluster, creating topics, and deleting topics. Each method includes proper error handling and logging using the `tracing` crate.
* [`src/admin/mod.rs`](diffhunk://#diff-6f6c66a14d5a8aeda3b2e1453080c430b88aa31eac6c9fddea6bc6a243985f3aR1-R12): Added new modules for the builder, client, and types. Re-exported `AdminClientBuilder` and `AdminClient` for external use, and provided a `builder` method on `AdminClient` to create a new builder instance.
* [`src/admin/types.rs`](diffhunk://#diff-fa03092725da39f794547b44f64a6fa351bb19597d26a276c8e31da5960de67eR1-R21): Defined types for `DefaultAdminClient` and `AdminResult`, and implemented the `AdminClient` struct with necessary traits and type aliases for managing Kafka topics and configurations.